### PR TITLE
documentation: configure vim for commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Art of debugging
 ### [Documentation of the projects](documentation/README.md)
 
 - [how to generate a changelog](documentation/generate-changelog.md)
+- [how to configure editors](documentation/editor-configurations.md)
 
 ### [Guidelines and procedures](./guidelines/README.md)
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -4,3 +4,4 @@ What could be useful to know to keep your project documented. Here, it's mainly
 concerning files such as release notes, changelogs, etc.
 
 - [how to generate a changelog](generate-changelog.md)
+- [how to configure editors](editor-configurations.md)

--- a/documentation/editor-configurations.md
+++ b/documentation/editor-configurations.md
@@ -1,0 +1,22 @@
+# Editor configurations
+
+## Commit messages
+
+For commit messages, the editor should help you to :
+
+- Write titles shorter than 51 chars.
+- Wrap body at 72 chars.
+- Check the spelling at least in english.
+
+### VI, Vim, Neovim
+
+```
+" Filetype detection
+filetype plugin on
+
+autocmd FileType gitcommit set textwidth=72
+set colorcolumn=+1  " Colors the tw+1 column
+autocmd FileType gitcommit set colorcolumn+=51
+autocmd FileType gitcommit setlocal spell
+autocmd FileType gitcommit setlocal spelllang=en
+```


### PR DESCRIPTION
* Adds a section on editor configurations.
* Adds the vim configuration for commit messages.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>
