### PR TITLE
fix: links from Base to Cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Feel free to add:
 ### [Base](./base/README.md)
 
 - [babel](base/babel.md)
+- [cypress](base/cypress.md)
 - [docker](base/docker.md)
 - [git](base/git.md)
 - [imports](base/imports.md)

--- a/base/README.md
+++ b/base/README.md
@@ -2,6 +2,6 @@
 
 Documentation of the core Invenio technologies.
 
-### [Cypress](base/cypress.md)
+### [Cypress](cypress.md)
 
-- [how to use Cypress integrated to RERO ILS](base/cypress.md)
+- [how to use Cypress integrated to RERO ILS](cypress.md)


### PR DESCRIPTION
* Fixes links from Base page to Cypress one.

Co-Authored-by: Olivier DOSSMANN <git@dossmann.net>