### PR TITLE
translations: clarify the dev pow on translations

### DIFF
--- a/translations/translations-workflow.md
+++ b/translations/translations-workflow.md
@@ -4,26 +4,41 @@
 
 1. [Introduction][6]
 1. [The regular workflow][3]
+   1. [From a developer point of view][13]
+   1. [From a translation manager point of view][14]
 1. [Some weblate settings][5]
 1. [Troubleshootings][11]
-1. [Tips for the translators][8] 
+1. [Tips for the translators][8]
 
 ## Introduction
 
 We're using weblate as a web service to help the translation process, through
-the hosted service of weblate: https://hosted.weblate.org/projects/rero_plus
+the hosted service of weblate: <https://hosted.weblate.org/projects/rero_plus>
 
-For our needs, on weblate, we have one project (named RERO +, with `rero_plus`
-as slug), with many *components*:
+For our needs, on weblate, we have one project (named RERO+, with `rero_plus`
+as slug), with several *components*:
 
 - `ng-core`.
 - `rero-ils`.
-- `rero-ils-public-search` (from the GitHub `rero-ils-ui`).
-- `rero-ils-admin` (from the GitHub `rero-ils-ui`).
+- `rero-ils-public-search` (from the project `rero-ils-ui`).
+- `rero-ils-admin` (from the project `rero-ils-ui`).
 - `sonar`.
 - `sonar-ui`.
 
 ## The regular workflow
+
+### From a developer point of view
+
+With this workflow, when developing, there's nothing to do related to the
+translations, except to add to the source code what's needed to the script to
+extract the strings to be translated, or, when necessary, to add string in the
+*manual translation* file.
+
+Testing the extraction to check the code is a good idea, though. But no files
+should be modified in the translation folders and subfolders (ie
+`rero_ils/translations` or `projects/admin/src/assets/rero-ils-ui/admin/i18n`).
+
+### From the translation manager point of view
 
 **We do not use the automatic workflow through the GitHub webhook, to avoid
 conflicts.**
@@ -35,25 +50,24 @@ branch.
 
 1. Some changes are done on the `dev` branch.
 1. Some changes are done on weblate.
-1. Ensure that on weblate, all changes is committed.
-1. Lock the component.
+1. Ensure that on weblate, all changes is committed (`wlc commit`).
+1. Lock the component (`wlc lock <component>`).
 1. Then ensure that on GitHub all translations pull requests are merged into
    `translations` branch.
 1. Fetch and pull new upstream commits (`translations` branch) on your local
    `translations` branch.
-1. Maybe, you want to squash several commits into one.
+1. You may want to squash several commits into one.
 1. Fetch new upstream commits (`dev` branch).
 1. Rebase your `translations` branch on the upstream `dev` branch.
 1. Extract messages, check that everything looks good.
+1. Update catalogs.
 1. Commit the changes in the already existing commit (`git amend`), to avoid
    adding a supplementary commit.
-1. Update catalogs.
-1. Commit changes in the precedent translation commit.
 1. Force push the `translations` branch upstream (`translations` branch too).
 1. On weblate, through the repository management settings, reset the weblate
    branch on the GitHub `translations` branch (The red *maintenance* dropdown
-   menu).
-1. Unlock the component.
+   menu or `wlc reset <component>`).
+1. Unlock the component (`wlc unlock <component>`).
 1. Inform on the translations Gitter room that the component is updated and
    open to translation.
 1. Repeat once a week, or when several US are merged into `dev` during the
@@ -61,7 +75,9 @@ branch.
 1. Before release process, and even a few day before, when every weblate
    changes and every `dev` branch changes are into the `translations` branch,
    switch to the `dev` branch and `git merge --ff-only` the `translations`
-   branch on it. If everything went as expected, you can then push upstream.
+   branch on it. If everything went as expected, you can then push upstream. \
+   You could also create a PR from the `translation` branch on the `dev`
+   branch.
 1. The `dev` branch can be deployed (or tested locally before) to be tested.
 1. After the release, be sure to update the `translations` branches locally and
    on weblate, of course.
@@ -79,12 +95,12 @@ branch.
   The same as the precedent setting, but adapted to the `sonar-ui`
   configuration.
 - on each component, [addons]:
-    - automatic translations, suggest strings for non translated strings, use
-      machine translations (deepl, weblate, weblate translation memory), with
-      80 thresold.
-    - squash git commits, per language, add contributors in the commit message,
-      copy paste the regular commit message.
-    - only for JSON based component, customize JSON output, with 2 space for
+  - automatic translations, suggest strings for non translated strings, use
+    machine translations (deepl, weblate, weblate translation memory), with
+    80 thresold.
+  - squash git commits, per language, add contributors in the commit message,
+    copy paste the regular commit message.
+  - only for JSON based component, customize JSON output, with 2 space for
       indentation.
 
 ## Troubleshootings
@@ -102,24 +118,24 @@ branch.
 ## Tips for the translators
 
 - Have a look, even shortly to the [weblate documentation][9]:
-    - Especially on [*Translating using Weblate*][10].
+  - Especially on [*Translating using Weblate*][10].
 - In each component, a language is the source code. It is in a darker green and
   has a specific icon: this language should not be translated, of course.
 - On the language overview of each component, there are some links to strings
   grouped by status: translated, to be reviewed, needing actions, and so on.
   This is actually useful.
 - In the same spirit, once a string is selected,
-    - on the right of the editor, you may have some information: on top a
-      glossary, if any, and on the bottom links to the source code, if it can
-      help to understand the context.
-    - below the left section, there are some tabs:
-        - nearby strings, which sometimes can help have a context,
-        - other occurences, which helps to be coherent,
-        - comment,
-        - machinery, which can provide automatic suggestions,
-        - other languages, to check how this string is translated in other
-          languages,
-        - history.
+  - on the right of the editor, you may have some information: on top a
+    glossary, if any, and on the bottom links to the source code, if it can
+    help to understand the context.
+  - below the left section, there are some tabs:
+    - nearby strings, which sometimes can help have a context,
+    - other occurences, which helps to be coherent,
+    - comment,
+    - machinery, which can provide automatic suggestions,
+    - other languages, to check how this string is translated in other
+      languages,
+    - history.
 
 ![](intro_weblate.jpg)
 
@@ -135,3 +151,5 @@ branch.
 [10]: https://docs.weblate.org/en/latest/user/translating.html
 [11]: #troubleshootings
 [12]: https://hosted.weblate.org/projects/rero_plus/
+[13]: #from-a-developer-point-of-view
+[14]: #from-a-translation-manager-point-of-view


### PR DESCRIPTION
* Clarify that the developers shouldn't update the translations files at
  all.
* Correct some minor unprecision on the translation workflow.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>
